### PR TITLE
cleanup local repository after job completion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,25 @@
       <artifactId>ant</artifactId>
       <version>1.7.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>maven-plugin</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-repository-metadata</artifactId>
+      <version>3.0.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.indexer</groupId>
+      <artifactId>indexer-artifact</artifactId>
+      <version>4.1.2</version>
+    </dependency>
   </dependencies>
   
   <distributionManagement>

--- a/src/main/java/org/jenkinsci/plugins/mavenrepocleaner/MavenRepoCleanerPostBuildTask.java
+++ b/src/main/java/org/jenkinsci/plugins/mavenrepocleaner/MavenRepoCleanerPostBuildTask.java
@@ -1,0 +1,73 @@
+package org.jenkinsci.plugins.mavenrepocleaner;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.maven.AbstractMavenProject;
+import hudson.maven.MavenModuleSet;
+import hudson.maven.MavenModuleSetBuild;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleProject;
+import hudson.remoting.VirtualChannel;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Publisher;
+import hudson.tasks.Recorder;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * @author: <a hef="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class MavenRepoCleanerPostBuildTask extends Recorder {
+
+    @DataBoundConstructor
+    public MavenRepoCleanerPostBuildTask() {
+
+    }
+
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+
+        final long started = build.getTimeInMillis();
+        FilePath.FileCallable<Collection<String>> cleanup =
+            new FilePath.FileCallable<Collection<String>>() {
+                public Collection<String> invoke(File repository, VirtualChannel channel) throws IOException, InterruptedException {
+                    return new RepositoryCleaner(started).clean(repository);
+                }
+            };
+        Collection<String> removed = build.getWorkspace().child(".repository").act(cleanup);
+        if (removed.size() > 0) {
+            listener.getLogger().println( removed.size() + " unused artifacts removed from private maven repository" );
+        }
+        return true;
+    }
+
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.NONE;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+
+        public DescriptorImpl() {
+            super(MavenRepoCleanerPostBuildTask.class);
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Cleanup maven repository for unused artifacts";
+        }
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return FreeStyleProject.class.isAssignableFrom(jobType)
+                    || AbstractMavenProject.class.isAssignableFrom(jobType);
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/mavenrepocleaner/RepositoryCleaner.java
+++ b/src/main/java/org/jenkinsci/plugins/mavenrepocleaner/RepositoryCleaner.java
@@ -1,0 +1,97 @@
+package org.jenkinsci.plugins.mavenrepocleaner;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import hudson.os.PosixAPI;
+import org.apache.commons.io.DirectoryWalker;
+import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.apache.maven.artifact.repository.metadata.Snapshot;
+import org.apache.maven.index.artifact.Gav;
+import org.apache.maven.index.artifact.M2GavCalculator;
+import org.jruby.ext.posix.FileStat;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+
+import javax.swing.filechooser.FileNameExtensionFilter;
+
+/**
+ * Hello world!
+ *
+ */
+public class RepositoryCleaner extends DirectoryWalker
+{
+    private M2GavCalculator gavCalculator = new M2GavCalculator();
+    private long olderThan;
+    private String root;
+
+    public RepositoryCleaner(long timestamp) {
+        this.olderThan = timestamp / 1000;
+    }
+
+    public Collection<String> clean(File repository) throws IOException {
+        this.root = repository.getAbsolutePath();
+        Collection<String> result = new ArrayList<String>();
+        walk(repository, result);
+        return result;
+    }
+
+    protected final void handleDirectoryStart(File directory, int depth, Collection results) throws IOException {
+
+        for (File file : directory.listFiles()) {
+            if (file.isDirectory()) continue;
+            String fileName = file.getName();
+
+            if (fileName.endsWith(".sha1") || fileName.endsWith(".md5")) continue;
+
+            String location = file.getAbsolutePath().substring(root.length());
+            Gav gav = gavCalculator.pathToGav(location);
+            if (gav == null) continue; // Not an artifact
+
+            olderThan(file, gav, results);
+        }
+
+        if ( directory.listFiles(new MetadataFileFilter()).length == 0 ) {
+            for (File file : directory.listFiles()) {
+                file.delete();
+            }
+            directory.delete();
+        }
+
+    }
+
+    private void olderThan(File file, Gav artifact, Collection results) {
+        FileStat fs = PosixAPI.get().lstat(file.getPath());
+        long lastAccessTime = fs.atime();
+        if (lastAccessTime < olderThan) {
+            // This artifact hasn't been accessed during build
+            clean(file, artifact, results);
+        }
+    }
+
+    private void clean(File file, Gav artifact, Collection results) {
+        File directory = file.getParentFile();
+        String fineName = gavCalculator.calculateArtifactName(artifact);
+        new File(directory, fineName + ".md5").delete();
+        new File(directory, fineName + ".sha1").delete();
+        file.delete();
+        results.add(gavCalculator.gavToPath(artifact));
+    }
+
+    private static class MetadataFileFilter implements FileFilter {
+
+        private final List<String> metadata =
+            Arrays.asList(new String[]
+                    {"_maven.repositories", "maven-metadata.xml", "maven-metadata.xml.md5", "maven-metadata.xml.sha1"});
+
+        public boolean accept(File file) {
+            return !metadata.contains(file.getName());
+        }
+    }
+}
+

--- a/src/main/resources/org/jenkinsci/plugins/mavenrepocleaner/MavenRepoCleanerPostBuildTask/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mavenrepocleaner/MavenRepoCleanerPostBuildTask/config.jelly
@@ -1,0 +1,3 @@
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/mavenrepocleaner/MavenRepoCleanerPostBuildTask/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/mavenrepocleaner/MavenRepoCleanerPostBuildTask/help.html
@@ -1,0 +1,3 @@
+<p>
+    Remove all maven artifacts that weren't used during the build, based on filesystem last access time.
+</p>


### PR DESCRIPTION
alternative to the already implemented cron-based cleanup
uses filesystem lastAccessTime to distinguish maven artifacts used during build from "legacy" ones. Only artifacts accessed during the build are kept in the local (private) repository, ensuring just-enough artifacts in the local cache
