### PR TITLE
Fix deleting artifacts that have not been accessed during the build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mavenrepocleaner/RepositoryCleaner.java
+++ b/src/main/java/org/jenkinsci/plugins/mavenrepocleaner/RepositoryCleaner.java
@@ -15,6 +15,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import java.util.concurrent.TimeUnit
+;
 /**
  * Hello world!
  *
@@ -63,7 +65,7 @@ public class RepositoryCleaner extends DirectoryWalker
     private void olderThan(File file, Gav artifact, Collection results) throws IOException {
         BasicFileAttributes attrs = Files.readAttributes(file.toPath(), BasicFileAttributes.class);
         FileTime time = attrs.lastAccessTime();
-        long lastAccessTime = time.toMillis();
+        long lastAccessTime = time.to(TimeUnit.SECONDS);
         if (lastAccessTime < olderThan) {
             // This artifact hasn't been accessed during build
             clean(file, artifact, results);


### PR DESCRIPTION
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

maven-repo-cleaner detects artifacts that have not been used during the build by comparing their last-access-time with the build timestamp. This is done with `second` precision (see https://github.com/jenkinsci/maven-repo-cleaner-plugin/blob/master/src/main/java/org/jenkinsci/plugins/mavenrepocleaner/MavenRepoCleanerPostBuildTask.java#L37 and here
https://github.com/jenkinsci/maven-repo-cleaner-plugin/blob/master/src/main/java/org/jenkinsci/plugins/mavenrepocleaner/RepositoryCleaner.java#L29)

With the change to avoid PosixAPI, this was broken by now comparing seconds with milliseconds (see https://github.com/jenkinsci/maven-repo-cleaner-plugin/commit/de65bae8d3b958a58b5b8840ce1c0a3351214a0e#diff-9d22f44ebe48fad873d92f52ee43ab992abdacb925085ba44139ca0fe35004f0R66)

This PR fixes this by comparing seconds with seconds again.